### PR TITLE
Added target parameter to open file response

### DIFF
--- a/lib/Response/OpenFileResponse.php
+++ b/lib/Response/OpenFileResponse.php
@@ -3,9 +3,22 @@
 namespace Phpactor\Extension\Rpc\Response;
 
 use Phpactor\Extension\Rpc\Response;
+use RuntimeException;
 
 class OpenFileResponse implements Response
 {
+    const TARGET_FOCUSED_WINDOW = 'focused_window';
+    const TARGET_VERTICAL_SPLIT = 'vsplit';
+    const TARGET_HORIZONTAL_SPLIT = 'hsplit';
+    const TARGET_NEW_TAB = 'new_tab';
+
+    const VALID_TARGETS = [
+        self::TARGET_FOCUSED_WINDOW,
+        self::TARGET_VERTICAL_SPLIT,
+        self::TARGET_HORIZONTAL_SPLIT,
+        self::TARGET_NEW_TAB
+    ];
+
     /**
      * @var string
      */
@@ -21,11 +34,17 @@ class OpenFileResponse implements Response
      */
     private $forceReload;
 
-    private function __construct(string $path, int $offset = 0, bool $forceReload = false)
+    /**
+     * @var string
+     */
+    private $target;
+
+    private function __construct(string $path, int $offset = 0, bool $forceReload = false, string $target = self::TARGET_FOCUSED_WINDOW)
     {
         $this->path = $path;
         $this->offset = $offset;
         $this->forceReload = $forceReload;
+        $this->target = $target;
     }
 
     public static function fromPath(string $path): OpenFileResponse
@@ -48,7 +67,8 @@ class OpenFileResponse implements Response
         return [
             'path' => $this->path,
             'offset' => $this->offset,
-            'force_reload' => $this->forceReload
+            'force_reload' => $this->forceReload,
+            'target' => $this->target,
         ];
     }
 
@@ -57,10 +77,30 @@ class OpenFileResponse implements Response
         return $this->path;
     }
 
+    public function target(): string
+    {
+        return $this->target;
+    }
+
     public function withForcedReload(bool $bool): OpenFileResponse
     {
         $new = clone $this;
         $new->forceReload = $bool;
+
+        return $new;
+    }
+
+    public function withTarget(string $target): OpenFileResponse
+    {
+        if (!in_array($target, self::VALID_TARGETS)) {
+            throw new RuntimeException(sprintf(
+                'Unknown target "%s", known targets "%s"',
+                $target,
+                implode('", "', self::VALID_TARGETS)
+            ));
+        }
+        $new = clone $this;
+        $new->target = $target;
 
         return $new;
     }

--- a/tests/Unit/Response/OpenFileResponseTest.php
+++ b/tests/Unit/Response/OpenFileResponseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\Extension\Rpc\Tests\Unit\Response;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\Rpc\Response\OpenFileResponse;
+use RuntimeException;
+
+class OpenFileResponseTest extends TestCase
+{
+    public function testReturnsDefaultTarget()
+    {
+        $response = OpenFileResponse::fromPath(__FILE__);
+        $this->assertEquals(OpenFileResponse::TARGET_FOCUSED_WINDOW, $response->target());
+    }
+
+    public function testExceptionOnInvalidTarget()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown target "nope"');
+        OpenFileResponse::fromPath(__FILE__)
+            ->withTarget('nope');
+    }
+
+    public function testReturnsConfiguredTarget()
+    {
+        $response = OpenFileResponse::fromPath(__FILE__)
+            ->withTarget(OpenFileResponse::TARGET_HORIZONTAL_SPLIT);
+        $this->assertEquals(OpenFileResponse::TARGET_HORIZONTAL_SPLIT, $response->target());
+    }
+
+    public function testReturnsParameters()
+    {
+        $response = OpenFileResponse::fromPathAndOffset(__FILE__, 6)
+            ->withTarget(OpenFileResponse::TARGET_HORIZONTAL_SPLIT)
+            ->withForcedReload(true);
+        $this->assertEquals([
+            'path' => __FILE__,
+            'offset' => 6,
+            'force_reload' => true,
+            'target' => OpenFileResponse::TARGET_HORIZONTAL_SPLIT
+        ], $response->parameters());
+    }
+}


### PR DESCRIPTION
Provide a hint as to how the editor should open the file, e.g. in a new
tab, a horizontal split, current "buffer" etc.